### PR TITLE
Fix: XMLNAME should be XMLName

### DIFF
--- a/cibToGoStruct/main.py
+++ b/cibToGoStruct/main.py
@@ -36,7 +36,7 @@ goStructTemplate = """
 {%- endmacro -%}
 
 type {{ convert_name(node.name) }} struct {
-    XMLNAME    xml.Name    `xml:"{{ node.name }}" json:"-"`
+    XMLName    xml.Name    `xml:"{{ node.name }}" json:"-"`
 {% for child in node.children %}
     {{ convert_name(child.name) }}{{ struct_type(child) }}{{ struct_tag(child) }}
 {% endfor %}


### PR DESCRIPTION
See: https://golang.org/pkg/encoding/xml/#Marshal

 The name for the XML elements is taken from, in order of preference:

- the tag on the XMLName field, if the data is a struct
- the value of the XMLName field of type Name
- the tag of the struct field used to obtain the data
- the name of the struct field used to obtain the data
- the name of the marshaled type
